### PR TITLE
Updated boot.sh to activate the ip_vs kernel module

### DIFF
--- a/templates/boot.sh
+++ b/templates/boot.sh
@@ -4,6 +4,8 @@
 source mukube_init_config
 hostnamectl set-hostname $NODE_NAME
 echo  "127.0.1.1	$NODE_NAME" >> /etc/hosts
+# Activate the ip_vs kernel module to allow for load balancing. Required by Keepalived.
+modprobe ip_vs
 case $NODE_TYPE in
     "master")
         echo "MASTER NODE SETUP"

--- a/templates/boot.sh
+++ b/templates/boot.sh
@@ -4,10 +4,10 @@
 source mukube_init_config
 hostnamectl set-hostname $NODE_NAME
 echo  "127.0.1.1	$NODE_NAME" >> /etc/hosts
-# Activate the ip_vs kernel module to allow for load balancing. Required by Keepalived.
-modprobe ip_vs
 case $NODE_TYPE in
     "master")
+        # Activate the ip_vs kernel module to allow for load balancing. Required by Keepalived.
+        modprobe ip_vs
         echo "MASTER NODE SETUP"
         # Import all the container image tarballs into containerd local registry
         for FILE in /root/container-images/*; do


### PR DESCRIPTION
Trying to fix keepalived bug, where the container dumps files in its root filesystem.
https://github.com/osixia/docker-keepalived/issues/6.