### PR TITLE
Added extraargs to the apiserver.

### DIFF
--- a/templates/ClusterConfiguration.yaml
+++ b/templates/ClusterConfiguration.yaml
@@ -14,8 +14,8 @@ apiServer:
   timeoutForControlPlane: 4m0s
   extraArgs:
     enable-admission-plugins: DefaultTolerationSeconds
-    default-not-ready-toleration-seconds: "10"
-    default-unreachable-toleration-seconds: "10"
+    default-not-ready-toleration-seconds: 10
+    default-unreachable-toleration-seconds: 10
 controllerManager: {}
 etcd:
   local:

--- a/templates/ClusterConfiguration.yaml
+++ b/templates/ClusterConfiguration.yaml
@@ -12,6 +12,10 @@ dns:
 scheduler: {}
 apiServer:
   timeoutForControlPlane: 4m0s
+  extraArgs:
+    enable-admission-plugins: DefaultTolerationSeconds
+    default-not-ready-toleration-seconds: "10"
+    default-unreachable-toleration-seconds: "10"
 controllerManager: {}
 etcd:
   local:


### PR DESCRIPTION
The eviction time for pods on unresponsive nodes has been reduced by setting extraArgs on the ApiServer according to this blogpost:
https://dbafromthecold.com/2020/04/08/adjusting-pod-eviction-time-in-kubernetes/#:~:text=One%20of%20the%20best%20features,up%20on%20a%20healthy%20node.&text=The%20default%20time%20that%20it,being%20moved%20is%205%20minutes