### PR TITLE
Give the host access to the cluster's DNS

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,7 +38,7 @@ A join token to use by other nodes joining the cluster. This is used to establis
 A key used to encrypt the certificates.
 
 ### CLUSTER_DNS
-Optional variable. If set this is the IP of the DNS server the cluster should use.
+The IP of the DNS server the cluster should use.
 
 ### LB_IP_RANGE_START
 First IP address in the range to allocate for the load balancer.

--- a/scripts/prepare_systemd_network.sh
+++ b/scripts/prepare_systemd_network.sh
@@ -10,11 +10,12 @@ $(<$TEMPLATES_DIR/10-systemd-network.network )
 EOF
 " > $OUTPUT_DIR/10-systemd-network.network
 
-# Configure the DNS by creating the resolv.conf 
-if [ $CLUSTER_DNS ]
-then
+# Configure the DNS by creating the resolv.conf
 eval "cat <<EOF
 $(<$TEMPLATES_DIR/resolv.conf)
 EOF
-" > $WORKING_DIR/etc/resolv.conf
-fi
+" > $WORKING_DIR/etc/resolv.conf.kubelet
+
+mkdir -p "$WORKING_DIR/etc/systemd/resolved.conf.d"
+
+cp "$TEMPLATES_DIR/cluster.local.conf" "$WORKING_DIR/etc/systemd/resolved.conf.d/"

--- a/templates/10-systemd-network.network
+++ b/templates/10-systemd-network.network
@@ -4,6 +4,7 @@ Name=${NODE_NETWORK_INTERFACE}
 [Network]
 Address=${NODE_HOST_IP}
 Gateway=${NODE_GATEWAY_IP}
+DNS=${CLUSTER_DNS}
 LinkLocalAddressing=no
 
 [DHCP]

--- a/templates/InitConfiguration.yaml
+++ b/templates/InitConfiguration.yaml
@@ -18,5 +18,5 @@ nodeRegistration:
   criSocket: unix:///var/run/crio/crio.sock
   kubeletExtraArgs:
     cgroup-driver: "systemd"
-    resolv-conf: /etc/resolv.conf
+    resolv-conf: /etc/resolv.conf.kubelet
   ${TAINT_MASTER_YAML}

--- a/templates/cluster.local.conf
+++ b/templates/cluster.local.conf
@@ -1,0 +1,4 @@
+[Resolve]
+# https://github.com/kubernetes/kubernetes/blob/bf000e87700a553d3936702c3c572be298bae5be/cmd/kubeadm/app/constants/constants.go#L637
+DNS=10.96.0.10
+Domains=~cluster.local


### PR DESCRIPTION
This is needed so CRI-O can resolve the IP of a service, inside the
cluster, pointing to a HTTP PROXY server.

cluster.local is configured as a routing domain, so ex:
nidhogg-argocd-server.yggdrasil.svc.cluster.local will be resolved by
using the cluster's DNS server.