### PR TITLE
Support using a HTTP proxy for CRI-O and Argo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,13 @@ url = $(shell echo $1 | cut -d % -f 3- )
 HELM_CHARTS += $(HELM_DIR)/$$(release)\#$$(namespace)\#$$(notdir $$(url))
 $(HELM_DIR)/$$(release)\#$$(namespace)\#$$(notdir $$(url)) : $(HELM_DIR)/.empty
 	curl -L $$(url) -o $$@ 
+	[ -f "config/values/$$(release).yaml" ] && cp "config/values/$$(release).yaml" "$(HELM_DIR)/values/"
 endef
 $(foreach L,$(shell cat $(HELM_REQUIREMENTS)),$(eval $(call DOWNLOAD_HELM_PACKAGE,$L))) 
 
 pack-helm-charts : $(HELM_DIR)/.empty $(HELM_CHARTS)
 $(HELM_DIR)/.empty :
-	mkdir -p $(@D) && touch $@ 
+	mkdir -p $(@D) $(@D)/values && touch $@
 
 ## docker-kubeadm: build the kubeadocker image used to generate join_tokens and certificates
 .PHONY : docker-kubeadm

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The entry point for the project is the make file in the root folder, which reads
 ### helm_requirements.txt
 All helm charts repos listed in this file will be downloaded and packed into the tarball. The charts will then be installed by the node that creates the cluster. Each line in the file should contain 3 things, seperated by a `%`: First the release name, second the namespace and lastly the url of the repo.
 
+### values/<helm release>.yaml
+Values to use for the helm release.
 
 ### Dependencies
 A user in the docker group

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,6 +11,8 @@ MASTER_CERTIFICATE_KEY=
 LB_IP_RANGE_START=
 LB_IP_RANGE_STOP=
 INGRESS_LB_IP_ADDRESS=
+PROXY_SERVER=
+PROXY_EXTERNAL_PROXY=
 ```
 
 #### NODE_CONTROL_PLANE_VIP
@@ -48,6 +50,12 @@ Last IP address in the range to allocate for the load balancer.
 
 ### INGRESS_LB_IP_ADDRESS
 Load balancer IP to allocate for the ingress.
+
+### PROXY_SERVER
+HTTP proxy which CRI-O and Argo should use (default: `http://nidhogg-lb-proxy.yggdrasil.svc.cluster.local:80`).
+
+### PROXY_EXTERNAL_PROXY
+External proxy server to pass to the internal TCP loadbalancer, which CRI-O and Argo use by default.
 
 ### Example file
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,6 +11,7 @@ MASTER_CERTIFICATE_KEY=
 LB_IP_RANGE_START=
 LB_IP_RANGE_STOP=
 INGRESS_LB_IP_ADDRESS=
+PROXY_ENABLED=
 PROXY_SERVER=
 PROXY_EXTERNAL_PROXY=
 ```
@@ -51,11 +52,14 @@ Last IP address in the range to allocate for the load balancer.
 ### INGRESS_LB_IP_ADDRESS
 Load balancer IP to allocate for the ingress.
 
+### PROXY_ENABLED
+(Optional) Configure CRI-O and Argo to use the HTTP proxy set by `HTTP_PROXY_SERVER` (default: `false`).
+
 ### PROXY_SERVER
-HTTP proxy which CRI-O and Argo should use (default: `http://nidhogg-lb-proxy.yggdrasil.svc.cluster.local:80`).
+(Optional) HTTP proxy which CRI-O and Argo should use (default: `http://nidhogg-lb-proxy.yggdrasil.svc.cluster.local:80`).
 
 ### PROXY_EXTERNAL_PROXY
-External proxy server to pass to the internal TCP loadbalancer, which CRI-O and Argo use by default.
+(Required if `PROXY_ENABLED` is `true`) External proxy server to pass to the internal TCP loadbalancer, which CRI-O and Argo use by default.
 
 ### Example file
 ```

--- a/scripts/build_cluster.sh
+++ b/scripts/build_cluster.sh
@@ -14,7 +14,7 @@ for node in $NODEDIR/*; do
 	#Pack the images and helm charts for master nodes
 	if [[ $node == *"master"* ]]; then
 		echo "	* adding helm-charts and container-images"
-		tar -rf $archive_path -C build root/helm-charts root/container-images --exclude **/.empty
+		tar -rf $archive_path -C build root/helm-charts root/container-images --exclude **/.empty --exclude root/helm-charts/values/nidhogg.yaml
 	fi
 	tmp="$(mktemp -d)"
 	cp "$archive_path" "$tmp/config.tar"

--- a/templates/boot.sh
+++ b/templates/boot.sh
@@ -50,6 +50,10 @@ case $NODE_TYPE in
               --set yggdrasil.loadbalancer.ipRangeStart=$$LB_IP_RANGE_START \
               --set yggdrasil.loadbalancer.ipRangeStop=$$LB_IP_RANGE_STOP \
               --set yggdrasil.ingress.loadBalancerIP=$$INGRESS_LB_IP_ADDRESS \
+              --set lb-proxy.enabled=true \
+              --set lb-proxy.config.externalProxy=$$PROXY_EXTERNAL_PROXY \
+              --set argo-cd-proxy-chart.config.httpProxy=$$PROXY_SERVER \
+              --set argo-cd-proxy-chart.config.serviceSubnet=10.96.0.0/12 \
               $release $FILE
         done
         ;;&

--- a/templates/boot.sh
+++ b/templates/boot.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+shopt -s extglob
 
 # Load all the variables from the config.yaml file to variables
 source mukube_init_config
@@ -43,18 +44,15 @@ case $NODE_TYPE in
         # Need to export KUBECONFIG for helm to contact the api-server
         export KUBECONFIG=/etc/kubernetes/admin.conf
         echo "Installing included helm charts"
-        for FILE in /root/helm-charts/*; do
+        for FILE in /root/helm-charts/!(values); do
             release=$(echo $FILE | cut -f4 -d/ | cut -f1 -d#)
             namespace=$(echo $FILE | cut -f4 -d/ | cut -f2 -d#)
-            helm install --create-namespace -n $namespace \
-              --set yggdrasil.loadbalancer.ipRangeStart=$$LB_IP_RANGE_START \
-              --set yggdrasil.loadbalancer.ipRangeStop=$$LB_IP_RANGE_STOP \
-              --set yggdrasil.ingress.loadBalancerIP=$$INGRESS_LB_IP_ADDRESS \
-              --set lb-proxy.enabled=true \
-              --set lb-proxy.config.externalProxy=$$PROXY_EXTERNAL_PROXY \
-              --set argo-cd-proxy-chart.config.httpProxy=$$PROXY_SERVER \
-              --set argo-cd-proxy-chart.config.serviceSubnet=10.96.0.0/12 \
-              $release $FILE
+            values_file="/root/helm-charts/values/$release.yaml"
+            if [ -f "$values_file" ]; then
+                helm install --create-namespace -f "$values_file" -n $namespace $release $FILE
+            else
+                helm install --create-namespace -n $namespace $release $FILE
+            fi
         done
         ;;&
     master-join)

--- a/templates/nidhogg-lb.yaml
+++ b/templates/nidhogg-lb.yaml
@@ -1,0 +1,6 @@
+yggdrasil:
+  loadbalancer:
+    ipRangeStart: $LB_IP_RANGE_START
+    ipRangeStop: $LB_IP_RANGE_STOP
+  ingress:
+    loadBalancerIP: $INGRESS_LB_IP_ADDRESS

--- a/templates/nidhogg-proxy.yaml
+++ b/templates/nidhogg-proxy.yaml
@@ -1,0 +1,8 @@
+lb-proxy:
+  enabled: true
+  config:
+    externalProxy: $PROXY_EXTERNAL_PROXY
+argo-cd-proxy-chart:
+  config:
+    httpProxy: $PROXY_SERVER
+    serviceSubnet: 10.96.0.0/12


### PR DESCRIPTION
Configure Nidhogg to start the lb-proxy service and configure CRI-O and Argo to use it.