### PR TITLE
Ensure the root certificate is readable

### DIFF
--- a/scripts/prepare_cluster.sh
+++ b/scripts/prepare_cluster.sh
@@ -106,6 +106,7 @@ for ((i=0; i<${#MASTERS[@]}; i++)); do
         if [ -n "$PROXY_CA_FILE" ]; then
             mkdir -p "$OUTPUT_DIR_MASTER/etc/crio/ssl/"
             cp "$PROXY_CA_FILE" "$OUTPUT_DIR_MASTER/etc/crio/ssl/root.pem"
+            chmod 444 "$OUTPUT_DIR_MASTER/etc/crio/ssl/root.pem"
             cat templates/nidhogg-proxy-ca.yaml >> "$OUTPUT_PATH_VALUES/nidhogg.yaml"
         fi
     fi
@@ -143,6 +144,7 @@ for ((i=0; i<${#WORKERS[@]}; i++)); do
         if [ -n "$PROXY_CA_FILE" ]; then
             mkdir -p "$OUTPUT_DIR_WORKER/etc/crio/ssl/"
             cp "$PROXY_CA_FILE" "$OUTPUT_DIR_WORKER/etc/crio/ssl/root.pem"
+            chmod 444 "$OUTPUT_DIR_MASTER/etc/crio/ssl/root.pem"
         fi
     fi
     cp templates/boot.sh $OUTPUT_DIR_WORKER

--- a/templates/registries.conf
+++ b/templates/registries.conf
@@ -1,9 +1,3 @@
 unqualified-search-registries = ["docker.io"]
 [[registry]]
-prefix = "docker.io"
 location = "docker.io"
-[[registry.mirror]]
-location = "registry.garagen"
-insecure = true
-[[registry.mirror]]
-location = "mirror.gcr.io"


### PR DESCRIPTION
The root certificate must be readable by CRI-O and Argo, so don't copy
the permission from the supplied root certificate but always make the
file world readable.

---

Provide a minimal `registries.conf` file to avoid the system default. 