### PR TITLE
Add option for configuring registry mirrors

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,7 @@ PROXY_EXTERNAL_PROXY=
 PROXY_CA_FILE=
 KUBECONFIG_HOST=
 KUBECONFIG_SSH_KEY=
+REGISTRY_MIRRORS=
 ```
 
 #### NODE_CONTROL_PLANE_VIP
@@ -75,6 +76,9 @@ Load balancer IP to allocate for the ingress.
 
 ### KUBECONFIG_SSH_KEY
 (Optional) SSH key to use for the transfer.
+
+### REGISTRY_MIRRORS
+(Optional) List of mirrors to configure in [`registries.conf.d`](https://github.com/containers/image/blob/70982d037a7a006fd3806dfb0882840aac2e2259/docs/containers-registries.conf.d.5.md), ex: `docker.io 192.168.1.10:5000 true,quay.io 192.168.1.20:5000 true` (`$registry $mirror $insecure`).
 
 ### Example file
 ```

--- a/scripts/prepare_cluster.sh
+++ b/scripts/prepare_cluster.sh
@@ -74,6 +74,16 @@ cat <<EOF > "$crio_sysconfig"
 http_proxy="$PROXY_SERVER"
 https_proxy="$PROXY_SERVER"
 EOF
+
+mirrors_conf="$(mktemp)"
+while IFS= read -r line; do
+  registry="$(awk '{print $1}' <<< "$line")"
+  mirror="$(awk '{print $2}' <<< "$line")"
+  insecure="$(awk '{print $3}' <<< "$line")"
+  # https://github.com/containers/image/blob/70982d037a7a006fd3806dfb0882840aac2e2259/docs/containers-registries.conf.5.md
+  printf '[[registry]]\nlocation = "%s"\n[[registry.mirror]]\nlocation = "%s"\ninsecure = %s\n\n' "$registry" "$mirror" "$insecure" >> "$mirrors_conf"
+done < <(tr ',' '\n' <<< "$REGISTRY_MIRRORS" | sed '/^[[:space:]]*$/d')
+
 if [ -n "$PROXY_CA_FILE" ]; then
     echo SSL_CERT_FILE=/etc/crio/ssl/root.pem >> "$crio_sysconfig"
 fi
@@ -97,8 +107,9 @@ for ((i=0; i<${#MASTERS[@]}; i++)); do
     OUTPUT_PATH_CONF=$OUTPUT_DIR_MASTER/mukube_init_config
     mkdir -p $OUTPUT_DIR_MASTER
 
-    mkdir -p $OUTPUT_DIR_MASTER/etc/containers/
+    mkdir -p $OUTPUT_DIR_MASTER/etc/containers/registries.conf.d/
     cp templates/registries.conf $OUTPUT_DIR_MASTER/etc/containers/
+    cp "$mirrors_conf" $OUTPUT_DIR_MASTER/etc/containers/registries.conf.d/mirrors.conf
     OUTPUT_PATH_VALUES="$OUTPUT_DIR_MASTER/root/helm-charts/values"
     mkdir -p "$OUTPUT_PATH_VALUES"
     eval "echo \"$(<templates/nidhogg-lb.yaml)\"" >> "$OUTPUT_PATH_VALUES/nidhogg.yaml"
@@ -146,8 +157,9 @@ for ((i=0; i<${#WORKERS[@]}; i++)); do
     OUTPUT_DIR_WORKER=$OUTPUT_DIR/$CLUSTER_NAME-worker$i
     mkdir -p $OUTPUT_DIR_WORKER
 
-    mkdir -p $OUTPUT_DIR_WORKER/etc/containers/
+    mkdir -p $OUTPUT_DIR_WORKER/etc/containers/registries.conf.d/
     cp templates/registries.conf $OUTPUT_DIR_WORKER/etc/containers/
+    cp "$mirrors_conf" $OUTPUT_DIR_WORKER/etc/containers/registries.conf.d/mirrors.conf
     if [ "$PROXY_ENABLED" = "true" ]; then
         mkdir -p "$OUTPUT_DIR_WORKER/etc/sysconfig"
         cp "$crio_sysconfig" "$OUTPUT_DIR_WORKER/etc/sysconfig/crio"
@@ -163,4 +175,4 @@ for ((i=0; i<${#WORKERS[@]}; i++)); do
     ./scripts/prepare_k8s_configs.sh $OUTPUT_DIR_WORKER templates
 done
 
-rm "$crio_sysconfig"
+rm "$crio_sysconfig" "$mirrors_conf"


### PR DESCRIPTION
It is faster using a local mirror and may be necessary to avoid Docker
Hub's rate limits[1].

[1] https://www.docker.com/increase-rate-limits