### PR TITLE
Ensure pods aren't started before the new CNI (Cilium)

### DIFF
--- a/scripts/prepare_k8s_configs.sh
+++ b/scripts/prepare_k8s_configs.sh
@@ -12,9 +12,7 @@ case $NODE_TYPE in
 	master*)
 		if [ $MASTER_TAINT == "true" ]
 		then 
-			export TAINT_MASTER_YAML=$'taints:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/master'
-		else
-			export TAINT_MASTER_YAML="taints: []"
+			export TAINT_MASTER_YAML=$'- effect: NoSchedule\n      key: node-role.kubernetes.io/master'
 		fi
 	;;&
 	master-init)

--- a/templates/InitConfiguration.yaml
+++ b/templates/InitConfiguration.yaml
@@ -15,4 +15,8 @@ certificateKey: ${MASTER_CERTIFICATE_KEY}
 nodeRegistration:
   name: ${NODE_NAME}
   criSocket: unix:///var/run/crio/crio.sock
-  ${TAINT_MASTER_YAML}
+  taints:
+    - key: "node.cilium.io/agent-not-ready"
+      value: "true"
+      effect: "NoSchedule"
+    ${TAINT_MASTER_YAML}

--- a/templates/JoinConfiguration.yaml
+++ b/templates/JoinConfiguration.yaml
@@ -11,5 +11,9 @@ nodeRegistration:
   kubeletExtraArgs:
     cgroup-driver: "systemd"
   criSocket: unix:///var/run/crio/crio.sock
-  ${TAINT_MASTER_YAML}
+  taints:
+    - key: "node.cilium.io/agent-not-ready"
+      value: "true"
+      effect: "NoSchedule"
+    ${TAINT_MASTER_YAML}
 ${CONTROL_PLANE_REGISTRATION}


### PR DESCRIPTION
Cilium is the new CNI[1][2][3] and pods must not be started before it is
running (achieved with a taint). Cilium automatically removes the taint.

If the pods are started before Cilium, the network won't work properly.

[1] https://github.com/distributed-technologies/helm-charts/pull/224
[2] https://github.com/distributed-technologies/helm-charts/pull/229
[3] https://github.com/distributed-technologies/yggdrasil/pull/61