### PR TITLE
Add options to configure external-dns

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -18,6 +18,10 @@ PROXY_CA_FILE=
 KUBECONFIG_HOST=
 KUBECONFIG_SSH_KEY=
 REGISTRY_MIRRORS=
+EXTERNAL_DNS_ENABLED=
+EXTERNAL_DNS_ZONE=
+EXTERNAL_DNS_PDNS_SERVER=
+EXTERNAL_DNS_PDNS_API_KEY=
 ```
 
 #### NODE_CONTROL_PLANE_VIP
@@ -79,6 +83,18 @@ Load balancer IP to allocate for the ingress.
 
 ### REGISTRY_MIRRORS
 (Optional) List of mirrors to configure in [`registries.conf.d`](https://github.com/containers/image/blob/70982d037a7a006fd3806dfb0882840aac2e2259/docs/containers-registries.conf.d.5.md), ex: `docker.io 192.168.1.10:5000 true,quay.io 192.168.1.20:5000 true` (`$registry $mirror $insecure`).
+
+### EXTERNAL_DNS_ENABLED
+(Optional) Configure [external-dns](https://github.com/kubernetes-sigs/external-dns) (default: `false`).
+
+### EXTERNAL_DNS_ZONE
+(Required if `EXTERNAL_DNS_ENABLED` is `true`) DNS zone to put records into.
+
+### EXTERNAL_DNS_PDNS_SERVER
+(Required if `EXTERNAL_DNS_ENABLED` is `true`) PowerDNS HTTP API URL.
+
+### EXTERNAL_DNS_PDNS_API_KEY
+(Required if `EXTERNAL_DNS_ENABLED` is `true`) PowerDNS API key.
 
 ### Example file
 ```

--- a/scripts/prepare_cluster.sh
+++ b/scripts/prepare_cluster.sh
@@ -105,6 +105,9 @@ for ((i=0; i<${#MASTERS[@]}; i++)); do
     OUTPUT_PATH_VALUES="$OUTPUT_DIR_MASTER/root/helm-charts/values"
     mkdir -p "$OUTPUT_PATH_VALUES"
     eval "echo \"$(<templates/nidhogg-lb.yaml)\"" >> "$OUTPUT_PATH_VALUES/nidhogg.yaml"
+    if [ "$EXTERNAL_DNS_ENABLED" = "true" ]; then
+        eval "echo \"$(<templates/nidhogg-external-dns.yaml)\"" >> "$OUTPUT_PATH_VALUES/nidhogg.yaml"
+    fi
     if [ "$PROXY_ENABLED" = "true" ]; then
         mkdir -p "$OUTPUT_DIR_MASTER/etc/sysconfig"
         cp "$crio_sysconfig" "$OUTPUT_DIR_MASTER/etc/sysconfig/crio"

--- a/templates/nidhogg-external-dns.yaml
+++ b/templates/nidhogg-external-dns.yaml
@@ -1,0 +1,11 @@
+  external-dns:
+    env:
+      - name: EXTERNAL_DNS_PDNS_SERVER
+        value: '$EXTERNAL_DNS_PDNS_SERVER'
+      - name: EXTERNAL_DNS_PDNS_API_KEY
+        value: '$EXTERNAL_DNS_PDNS_API_KEY'
+      - name: EXTERNAL_DNS_FQDN_TEMPLATE
+        value: '{{.Name}}.$EXTERNAL_DNS_ZONE'
+    policy: sync
+    domainFilters: [$EXTERNAL_DNS_ZONE]
+    provider: pdns


### PR DESCRIPTION
"ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with
DNS providers."[1]

We need this to ease access to development clusters, by synchronizing
Services and Ingresses into a internal DNS zone.

This commit adds the final wiring, so the zone can be set as part of the
cluster provisioning. See [2] and [3], for the chart and yggdrasil
changes.

[1] https://github.com/kubernetes-sigs/external-dns
[2] https://github.com/distributed-technologies/helm-charts/pull/264
[3] https://github.com/distributed-technologies/yggdrasil/pull/75