### PR TITLE
Switch to Vault's AppRole for authentication

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -30,7 +30,8 @@ FLUX_GIT_TOKEN=
 FLUX_PATH=
 FLUX_CILIUM_HELM_RELEASE=
 VAULT_SERVER=
-VAULT_TOKEN=
+VAULT_ROLE_ID=
+VAULT_SECRET_ID=
 ```
 
 #### NODE_CONTROL_PLANE_VIP
@@ -129,8 +130,11 @@ Load balancer IP to allocate for the ingress.
 ### VAULT_SERVER
 (Optional) [Vault](https://www.vaultproject.io/) server which [External Secrets](https://external-secrets.io) should use (default: ``).
 
-### VAULT_TOKEN
-(Required if `VAULT_SERVER` is specified) Token to the [Vault](https://www.vaultproject.io/) server (default: ``).
+### VAULT_ROLE_ID
+(Required if `VAULT_SERVER` is specified) AppRole RoleID to the [Vault](https://www.vaultproject.io/) server (default: ``).
+
+### VAULT_SECRET_ID
+(Required if `VAULT_SERVER` is specified) AppRole SecretID to the [Vault](https://www.vaultproject.io/) server (default: ``).
 
 ### Example file
 ```

--- a/scripts/prepare_cluster.sh
+++ b/scripts/prepare_cluster.sh
@@ -217,9 +217,11 @@ for ((i=0; i<${#MASTERS[@]}; i++)); do
             cluster_vars[lb_ip_range_start]="$LB_IP_RANGE_START"
             cluster_vars[lb_ip_range_stop]="$LB_IP_RANGE_STOP"
 
-            if [ -n "$VAULT_SERVER" ] && [ -n "$VAULT_TOKEN" ]; then
-                cluster_vars_secret[vault_server]="$VAULT_SERVER"
-                cluster_vars_secret[vault_token]="$VAULT_TOKEN"
+            mkdir -p "$OUTPUT_DIR_MASTER/root/"
+            if [ -n "$VAULT_SERVER" ] && [ -n "$VAULT_ROLE_ID" ] && [ -n "$VAULT_SECRET_ID" ]; then
+                cluster_vars[vault_server]="$VAULT_SERVER"
+                cluster_vars[vault_role_id]="$VAULT_ROLE_ID"
+                cluster_vars_secret[vault_secret_id]="$VAULT_SECRET_ID"
             fi
             if [ "$PROXY_ENABLED" = "true" ] && [ -n "$PROXY_CA_FILE" ]; then
                 cluster_vars[proxy_server]="$PROXY_SERVER"


### PR DESCRIPTION
After experimenting a bit with Vault, using a AppRole[1] seems to be a
better solution. Especially due to tokens inheriting the "identity
policies"[2], which makes it difficult/impossible to create a token with
a very restrictive policy.

[1] https://www.vaultproject.io/docs/auth/approle
[2] https://github.com/hashicorp/vault/issues/9623