### PR TITLE
Add option for adjusting the rootfs size

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@ VAULT_SERVER=
 VAULT_ROLE_ID=
 VAULT_SECRET_ID=
 SYSTEM_RESERVED_MEMORY=
+ROOTFS_SIZE=
 ```
 
 #### NODE_CONTROL_PLANE_VIP
@@ -135,6 +136,9 @@ Load balancer IP to allocate for the ingress.
 
 ### SYSTEM_RESERVED_MEMORY
 (Optional) How many GiB of memory reserved for the system that cannot be consumed by Kubernetes (default: `21`).
+
+### ROOTFS_SIZE
+(Optional) Size of the rootfs in GiB. Please also edit `SYSTEM_RESERVED_MEMORY` if you change this (default: `20`)
 
 ### Example file
 ```

--- a/scripts/prepare_cluster.sh
+++ b/scripts/prepare_cluster.sh
@@ -63,6 +63,7 @@ export KUBECONFIG_HOST
 export KUBECONFIG_SSH_KEY
 FLUX_GIT_BRANCH=${FLUX_GIT_BRANCH:-main}
 FLUX_PATH=${FLUX_PATH:-clusters/my-cluster/flux-system}
+ROOTFS_SIZE=${ROOTFS_SIZE:-20}
 
 crio_sysconfig="$(mktemp)"
 cat <<EOF > "$crio_sysconfig"
@@ -226,6 +227,7 @@ for ((i=0; i<${#MASTERS[@]}; i++)); do
     ./scripts/prepare_master_HA.sh $OUTPUT_DIR_MASTER templates
     ./scripts/prepare_k8s_configs.sh $OUTPUT_DIR_MASTER templates
     cp templates/boot.sh $OUTPUT_DIR_MASTER
+    sed -e "s/\$\${ROOTFS_SIZE}/$ROOTFS_SIZE/" -i $OUTPUT_DIR_MASTER/boot.sh
     if [ -n "$KUBECONFIG_HOST" ]; then
         mkdir $OUTPUT_DIR_MASTER/root/k8s/ $OUTPUT_DIR_MASTER/root/.ssh
         cp templates/readonly.yaml $OUTPUT_DIR_MASTER/root/k8s/
@@ -260,6 +262,7 @@ for ((i=0; i<${#WORKERS[@]}; i++)); do
         fi
     fi
     cp templates/boot.sh $OUTPUT_DIR_WORKER
+    sed -e "s/\$\${ROOTFS_SIZE}/$ROOTFS_SIZE/" -i $OUTPUT_DIR_MASTER/boot.sh
     ./scripts/prepare_node_config.sh $OUTPUT_DIR_WORKER/mukube_init_config $VARIABLES
     ./scripts/prepare_systemd_network.sh $OUTPUT_DIR_WORKER templates
     ./scripts/prepare_k8s_configs.sh $OUTPUT_DIR_WORKER templates

--- a/templates/boot.sh
+++ b/templates/boot.sh
@@ -13,6 +13,7 @@ case $NODE_TYPE in
         # General setup
         hostname $NODE_NAME
         echo  "127.0.1.1	$NODE_NAME" >> /etc/hosts
+        mount -o remount,size=$${ROOTFS_SIZE}G /
         ;;&
     master*)
         echo "MASTER NODE SETUP"


### PR DESCRIPTION
k8s-os defaults to 90%[1] of the host's memory, which is a lot. This adds a option for setting a absolute value, so that enough memory can be secured for the workloads.

[1] https://github.com/distributed-technologies/k8s-os/blob/1c93feb55bd94bda54be175dbf94ded23ef0dbd0/files/init#L10