### PR TITLE
Resolve .local via unicast DNS

### DIFF
--- a/templates/10-systemd-network.network
+++ b/templates/10-systemd-network.network
@@ -6,6 +6,7 @@ Address=${NODE_HOST_IP}/${MASTER_VIP_CLUSTER_CIDR}
 Gateway=${NODE_GATEWAY_IP}
 DNS=${CLUSTER_DNS}
 LinkLocalAddressing=no
+Domains=local.
 
 [DHCP]
 ClientIdentifier=mac


### PR DESCRIPTION
.local is sometimes used for internal DNS zones, so define it as a search domain, so systemd-resolved will use unicast DNS for it, as stated in the documentation:
"[..] Note that by default, lookups for domains with the ".local" suffix are not routed to DNS servers, unless the domain is specified explicitly as routing or search domain for the DNS server and interface. This means that on networks where the ".local" domain is defined in a site-specific DNS server, explicit search or routing domains need to be configured to make lookups work within this DNS domain. Note that these days, it's generally recommended to avoid defining ".local" in a DNS server, as RFC6762 reserves this domain for exclusive MulticastDNS use."[1]

[1] https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html#Protocols%20and%20Routing